### PR TITLE
centos7 report wrong free memory

### DIFF
--- a/aws-scripts-mon/mon-put-instance-data.pl
+++ b/aws-scripts-mon/mon-put-instance-data.pl
@@ -368,6 +368,7 @@ if ($report_mem_util || $report_mem_used || $report_mem_avail || $report_swap_ut
   # meminfo values are in kilobytes
   my $mem_total = $meminfo{'MemTotal'} * KILO;
   my $mem_free = $meminfo{'MemFree'} * KILO;
+  
   my $mem_cached = $meminfo{'Cached'} * KILO;
   my $mem_buffers = $meminfo{'Buffers'} * KILO;
   my $mem_avail = $mem_free + $mem_cached + $mem_buffers;


### PR DESCRIPTION
To add Centos 7 support for free memory, you could insert at line 370 an if statement to chek wheder a variable named 

$meminfo{'MemAvailable'}

exists and in case use it instead of

$meminfo{'MemFree'} 

for the $mem_free assignment.
